### PR TITLE
Release 1.0.0: Adds new variables to fix opinionated routing rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,6 @@
 locals {
-  dns_name  = "${var.override_dns_name != "" ? var.override_dns_name : replace(var.component_name, "/-service$/", "")}"
-  host_name = "${var.env == "live" ? "${local.dns_name}.${var.dns_domain}" : "${var.env}-${local.dns_name}.${var.dns_domain}"}"
-}
-
-data "aws_route53_zone" "dns_domain" {
-  name = "${var.dns_domain}"
+  logical_dns_service_name = "${var.override_dns_name != "" ? var.override_dns_name : replace(var.component_name, "/-service$/", "")}"
+  target_host_name         = "${var.env == "live" ? "" : "${var.env}-"}${local.logical_dns_service_name}.${var.dns_domain}"
 }
 
 resource "aws_alb_listener_rule" "rule" {
@@ -18,7 +14,7 @@ resource "aws_alb_listener_rule" "rule" {
 
   condition {
     field  = "host-header"
-    values = ["${local.host_name}"]
+    values = ["${local.target_host_name}"]
   }
 
   condition {
@@ -65,9 +61,20 @@ resource "aws_alb_target_group" "target_group" {
   }
 }
 
+locals {
+  logical_service_name = "${var.env}-${replace(var.component_name, "/-service$/", "")}"
+  full_account_name    = "${var.env == "live" ? "${var.aws_account_alias}prod" : "${var.aws_account_alias}dev"}"
+  backend_dns_domain   = "${local.full_account_name}.${var.backend_dns}"
+  backend_dns_record   = "${local.logical_service_name}.${local.backend_dns_domain}"
+}
+
+data "aws_route53_zone" "dns_domain" {
+  name = "${local.backend_dns_domain}"
+}
+
 resource "aws_route53_record" "dns_record" {
   zone_id = "${data.aws_route53_zone.dns_domain.zone_id}"
-  name    = "${local.host_name}"
+  name    = "${local.backend_dns_record}"
 
   type            = "CNAME"
   records         = ["${var.alb_dns_name}"]

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
   logical_dns_service_name = "${var.override_dns_name != "" ? var.override_dns_name : replace(var.component_name, "/-service$/", "")}"
-  target_host_name         = "${var.env == "live" ? "" : "${var.env}-"}${local.logical_dns_service_name}.${var.dns_domain}"
+  env_prefix               = "${var.env == "live" ? "" : "${var.env}-"}"
+  target_host_name         = "${local.env_prefix}${local.logical_dns_service_name}.${var.dns_domain}"
 }
 
 resource "aws_alb_listener_rule" "rule" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,6 +4,6 @@ output "target_group_arn" {
 }
 
 output "dns_name" {
-  value       = "${local.dns_name}.${var.dns_domain}"
+  value       = "${local.target_host_name}"
   description = "The DNS name for the service."
 }

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -9,6 +9,8 @@ module "backend_service_routing" {
   alb_listener_arn = "alb:listener"
   alb_dns_name     = "alb.dns.name.com"
   vpc_id           = "${var.platform_config["vpc"]}" # optional
+  aws_account_alias = "${var.aws_account_alias}"
+  backend_dns       = "${var.backend_dns}"
 }
 
 # configure provider to not try too hard talking to AWS API
@@ -30,3 +32,7 @@ variable "env" {}
 variable "platform_config" {
   type = "map"
 }
+
+variable "aws_account_alias" {}
+
+variable "backend_dns" {}

--- a/test/test_tf_backend_service_routing.py
+++ b/test/test_tf_backend_service_routing.py
@@ -14,6 +14,8 @@ class TestTFBackendRouter(unittest.TestCase):
             'plan',
             '-var', 'env=dev',
             '-var', 'aws_region=eu-west-1',
+            '-var', 'aws_account_alias=awsaccount',
+            '-var', 'backend_dns=testbackend.com',
             '-var-file=test/platform-config/eu-west-1.json',
             '-target=module.backend_service_routing.aws_alb_listener_rule.rule',
             '-no-color',
@@ -32,6 +34,8 @@ Plan: 2 to add, 0 to change, 0 to destroy.
             'plan',
             '-var', 'env=dev',
             '-var', 'aws_region=eu-west-1',
+            '-var', 'aws_account_alias=awsaccount',
+            '-var', 'backend_dns=testbackend.com',
             '-var-file=test/platform-config/eu-west-1.json',
             '-target=module.backend_service_routing.aws_alb_listener_rule.rule',
             '-no-color',
@@ -65,6 +69,8 @@ Plan: 2 to add, 0 to change, 0 to destroy.
             'plan',
             '-var', 'env=live',
             '-var', 'aws_region=eu-west-1',
+            '-var', 'aws_account_alias=awsaccount',
+            '-var', 'backend_dns=testbackend.com',
             '-var-file=test/platform-config/eu-west-1.json',
             '-target=module.backend_service_routing.aws_alb_listener_rule.rule',
             '-no-color',
@@ -98,6 +104,8 @@ Plan: 2 to add, 0 to change, 0 to destroy.
             'plan',
             '-var', 'env=dev',
             '-var', 'aws_region=eu-west-1',
+            '-var', 'aws_account_alias=awsaccount',
+            '-var', 'backend_dns=testbackend.com',
             '-var-file=test/platform-config/eu-west-1.json',
             '-target=module.backend_service_routing.aws_alb_listener_rule.rule',
             '-no-color',
@@ -135,3 +143,4 @@ Plan: 2 to add, 0 to change, 0 to destroy.
       target_type:                        "instance"
       vpc_id:                             "vpc-12345678"
         """.strip() in output
+

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "override_dns_name" {
 }
 
 variable "dns_domain" {
-  description = "The top level domain the service should live under - e.g. mmgapi.net. If blank (the default) then no DNS record will be created"
+  description = "The top level domain the service should live under. This will be the host used for the rule to route to a target group"
   default     = ""
 }
 
@@ -93,4 +93,14 @@ variable "hash_target_group_name" {
   description = "Include a hash of the target group name when naming it to avoid collisions"
   type        = "string"
   default     = "false"
+}
+
+variable "aws_account_alias" {
+  description = "The AWS account alias where the router is deployed"
+  type        = "string"
+}
+
+variable "backend_dns" {
+  description = "The domain and top level domain used as the address for the ALB"
+  type        = "string"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,28 +1,4 @@
-variable "env" {
-  description = "The name of the environment (included at the front of the DNS name with a hyphen if not live)"
-}
-
-variable "component_name" {
-  type        = "string"
-  description = "The name of the component - used by default for the DNS entry (with the -service suffix removed), as well as to give the target group a meaningful name"
-  default     = ""
-}
-
-variable "override_dns_name" {
-  type        = "string"
-  description = "The first part of the DNS name without the environment (defaults to component_name with -service suffix removed)"
-  default     = ""
-}
-
-variable "dns_domain" {
-  description = "The top level domain the service should live under. This will be the host used for the rule to route to a target group"
-  default     = ""
-}
-
-variable "ttl" {
-  description = "Time to live"
-  default     = "60"
-}
+// Required Variables
 
 variable "alb_dns_name" {
   description = "The DNS name of the ALB to point the DNS at"
@@ -30,6 +6,20 @@ variable "alb_dns_name" {
 
 variable "alb_listener_arn" {
   description = "The ARN of the ALB listener to add the rule to."
+}
+
+variable "aws_account_alias" {
+  description = "The AWS account alias where the router is deployed"
+  type        = "string"
+}
+
+variable "backend_dns" {
+  description = "The domain and top level domain used as the address for the ALB"
+  type        = "string"
+}
+
+variable "env" {
+  description = "The name of the environment (included at the front of the DNS name with a hyphen if not live)"
 }
 
 variable "priority" {
@@ -41,16 +31,53 @@ variable "vpc_id" {
   type        = "string"
 }
 
+// Optional Variables
+
+variable "allow_overwrite" {
+  description = "Allow creation of this record in Terraform to overwrite an existing record, if any."
+  type        = "string"
+  default     = "false"
+}
+
+variable "component_name" {
+  type        = "string"
+  description = "The name of the component - used by default for the DNS entry (with the -service suffix removed), as well as to give the target group a meaningful name"
+  default     = ""
+}
+
 variable "deregistration_delay" {
   description = "The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds."
   type        = "string"
   default     = "10"
 }
 
+variable "dns_domain" {
+  description = "The top level domain the service should live under. This will be the host used for the rule to route to a target group"
+  default     = ""
+}
+
+variable "hash_target_group_name" {
+  description = "Include a hash of the target group name when naming it to avoid collisions"
+  type        = "string"
+  default     = "false"
+}
+
 variable "health_check_interval" {
   description = "The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds."
   type        = "string"
   default     = "5"
+}
+
+variable "health_check_healthy_threshold" {
+  description = "The number of consecutive health checks successes required before considering an unhealthy target healthy."
+  type        = "string"
+  default     = "2"
+}
+
+variable "health_check_matcher" {
+  description = "The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, \"200,202\") or a range of values (for example, \"200-299\")."
+  type        = "string"
+  default     = "200-299"
 }
 
 variable "health_check_path" {
@@ -65,42 +92,19 @@ variable "health_check_timeout" {
   default     = "4"
 }
 
-variable "health_check_healthy_threshold" {
-  description = "The number of consecutive health checks successes required before considering an unhealthy target healthy."
-  type        = "string"
-  default     = "2"
-}
-
 variable "health_check_unhealthy_threshold" {
   description = "The number of consecutive health check failures required before considering the target unhealthy."
   type        = "string"
   default     = "2"
 }
 
-variable "health_check_matcher" {
-  description = "The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, \"200,202\") or a range of values (for example, \"200-299\")."
+variable "override_dns_name" {
   type        = "string"
-  default     = "200-299"
+  description = "The first part of the DNS name without the environment (defaults to component_name with -service suffix removed)"
+  default     = ""
 }
 
-variable "allow_overwrite" {
-  description = "Allow creation of this record in Terraform to overwrite an existing record, if any."
-  type        = "string"
-  default     = "false"
-}
-
-variable "hash_target_group_name" {
-  description = "Include a hash of the target group name when naming it to avoid collisions"
-  type        = "string"
-  default     = "false"
-}
-
-variable "aws_account_alias" {
-  description = "The AWS account alias where the router is deployed"
-  type        = "string"
-}
-
-variable "backend_dns" {
-  description = "The domain and top level domain used as the address for the ALB"
-  type        = "string"
+variable "ttl" {
+  description = "Time to live"
+  default     = "60"
 }


### PR DESCRIPTION
The new variables are required. Breaking any existing uses of the module.

We need the aws_account_alias to create the backend record.

The output for the dns_name is now the target_host_name as this is what
users will be using to reach the service.

Also, reordered the vars so they're in alphabetical order.

