### PR TITLE
Allow to add extra host in listener rule host header

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ locals {
   logical_dns_service_name = var.override_dns_name != "" ? var.override_dns_name : replace(var.component_name, "/-service$/", "")
   env_prefix               = var.env == "live" ? "" : "${var.env}-"
   target_host_name         = "${local.env_prefix}${local.logical_dns_service_name}.${var.dns_domain}"
+  host_header_host_names   = concat([local.target_host_name], var.extra_listener_host_names)
 }
 
 resource "aws_alb_listener_rule" "rule" {
@@ -15,7 +16,7 @@ resource "aws_alb_listener_rule" "rule" {
 
   condition {
     host_header {
-      values = ["${local.target_host_name}"]
+      values = local.host_header_host_names
     }
   }
 

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -11,6 +11,8 @@ module "backend_service_routing" {
   vpc_id            = var.platform_config["vpc"]
   aws_account_alias = var.aws_account_alias
   backend_dns       = var.backend_dns
+
+  extra_listener_host_names = var.extra_listener_host_names
 }
 
 # configure provider to not try too hard talking to AWS API
@@ -36,3 +38,8 @@ variable "platform_config" {
 variable "aws_account_alias" {}
 
 variable "backend_dns" {}
+
+variable "extra_listener_host_names" {
+  type = list(string)
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -113,3 +113,9 @@ variable "target_type" {
   description = "The possible values are instance (targets are specified by instance ID) or ip (targets are specified by IP address) or lambda (targets are specified by lambda arn)"
   default     = "instance"
 }
+
+variable "extra_listener_host_names" {
+  description = "A list of hostname to be included in the host header for the ALB listener rule"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
This is needed in case the backend is also integrated with a public api-gateway